### PR TITLE
Feat/executable can be directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
           pip install .
 
       - name: Build Python package
+        if: matrix.os == 'ubuntu-latest'
         run: python -m build
 
       - name: Publish to PyPI
@@ -53,16 +54,69 @@ jobs:
           sudo apt-get install -y ruby ruby-dev build-essential rpm fakeroot tar libarchive-tools
           sudo gem install --no-document fpm
           make deb pacman rpm
-
+      - name: Install Rosetta (if needed)
+        if: matrix.os == 'macos-latest'
+        run: |
+          sudo /usr/sbin/softwareupdate --install-rosetta --agree-to-license || true
+      - name: Build universal binary with lipo (arm64 + x86_64)
+        if: matrix.os == 'macos-latest'
+        run: |
+            mkdir -p dist-universal
+            cp dist/xcsp dist-universal/xcsp-arm64
+            arch -x86_64 pyinstaller --onefile --name xcsp-x86_64 --paths=. bin/main.py
+            cp dist/xcsp-x86_64 dist-universal/xcsp-x86_64
+            lipo -create dist-universal/xcsp-arm64 dist-universal/xcsp-x86_64 -output dist-universal/xcsp
+      - name: Import Apple certificate
+        if: matrix.os == 'macos-latest'
+        run: |
+          echo "$CERT_P12_BASE64" | base64 --decode > certificate.p12
+          security create-keychain -p "" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+          security import certificate.p12 -k build.keychain -P "$CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" build.keychain
+        env:
+          CERT_P12_BASE64: ${{ secrets.CERT_P12_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
+      - name: Sign macOS binary
+        if: matrix.os == 'macos-latest'
+        run: |
+          codesign --timestamp --options runtime \
+            --sign "Developer ID Application" \
+            dist-universal/xcsp
+      - name: Notarize macOS binary with Apple
+        if: matrix.os == 'macos-latest'
+        run: |
+          xcrun notarytool submit dist-universal/xcsp \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_APP_SPECIFIC_PWD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PWD: ${{ secrets.APPLE_APP_SPECIFIC_PWD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      - name: Staple notarization ticket
+        if: matrix.os == 'macos-latest'
+        run: |
+          xcrun stapler staple dist-universal/xcsp
+      - name: Package signed universal binary for Homebrew
+        if: matrix.os == 'macos-latest'
+        run: |
+          mkdir -p brew_tmp/bin brew_tmp/share/xcsp-launcher/configs brew_tmp/share/xcsp-launcher/tools
+          cp dist-universal/xcsp brew_tmp/bin/xcsp-macos
+          cp -r configs/* brew_tmp/share/xcsp-launcher/configs/
+          cp xcsp/tools/xcsp3-solutionChecker-2.5.jar brew_tmp/share/xcsp-launcher/tools/
+          tar -czvf xcsp-$(git describe --tags --abbrev=0)-macos.tar.gz -C brew_tmp .
       - name: Homebrew (macOS only)
         if: matrix.os == 'macos-latest'
         run: |
-          make brew
+          sha256=$(shasum -a 256 xcsp-$(git describe --tags --abbrev=0)-macos.tar.gz | awk '{print $1}')
+          url="https://github.com/CPToolset/xcsp-launcher/releases/download/$(git describe --tags --abbrev=0)/xcsp-$(git describe --tags --abbrev=0)-macos.tar.gz"
+          sed -e "s|__URL__|$url|" -e "s|__SHASUM__|$sha256|" .packaging/homebrew/xcsp.rb.template > .packaging/homebrew/xcsp.rb
           git clone --quiet https://x-access-token:${{ secrets.XCSP_GITHUB_TOKEN }}@github.com/CPToolset/homebrew-xcsp-launcher.git brew-tap
-          mkdir -p brew-tap/Formula/
           cp .packaging/homebrew/xcsp.rb brew-tap/Formula/xcsp.rb
-          cd brew-tap && git add Formula/ && git commit -m "Update formula for version $(VERSION)" && git push
-          rm -rf brew-tap
+          cd brew-tap && git add Formula/xcsp.rb && git commit -m "Update formula for version $(git describe --tags --abbrev=0)" && git push
         env:
           GITHUB_TOKEN: ${{ secrets.XCSP_GITHUB_TOKEN }}
 
@@ -86,7 +140,7 @@ jobs:
             *.deb
             *.rpm
             *.pkg.tar.*
-            *.tar.gz
+            xcsp-*-macos.tar.gz
             *.snap
             chocolatey/*.nupkg
 

--- a/Makefile
+++ b/Makefile
@@ -49,39 +49,39 @@ deb: $(DIST_DIR)/$(BIN_NAME)
 	cp package/*.deb .
 	rm -rf package
 
-# Créer une Formula Homebrew à partir du tar.gz
-brew: $(DIST_DIR)/$(BIN_NAME)
-	@echo "Building Homebrew formula..."
-
-	# Générer un tar.gz contenant juste l'exécutable et les configs
-	mkdir -p brew_tmp/bin brew_tmp/share/xcsp-launcher/configs brew_tmp/share/xcsp-launcher/tools
-	cp $(DIST_DIR)/$(BIN_NAME) brew_tmp/bin/xcsp-macos
-	cp $(DIST_DIR)/${BIN_NAME} $(DIST_DIR)/xcsp-macos
-	cp -r configs/* brew_tmp/share/xcsp-launcher/configs/
-	cp xcsp/tools/xcsp3-solutionChecker-2.5.jar brew_tmp/share/xcsp-launcher/tools/xcsp3-solutionChecker-2.5.jar
-
-	# Créer archive
-	tar -czvf xcsp-$(VERSION:v%=%)-macos.tar.gz -C brew_tmp .
-
-	{ \
-		sha256=$$(shasum -a 256 xcsp-$(VERSION:v%=%)-macos.tar.gz | awk '{print $$1}'); \
-		url="https://github.com/CPToolset/xcsp-launcher/releases/download/$(VERSION)/xcsp-$(VERSION:v%=%)-macos.tar.gz"; \
-		sed \
-			-e "s|__URL__|$$url|" \
-			-e "s|__SHASUM__|$$sha256|" \
-			.packaging/homebrew/xcsp.rb.template > .packaging/homebrew/xcsp.rb; \
-	}
-
-	# Nettoyer temporaire
-	rm -rf brew_tmp
-
-publish-brew: xcsp-*-macos.tar.gz
-	@echo "Publishing Homebrew Formula..."
-	git clone https://github.com/CPToolset/homebrew-xcsp-launcher.git brew-tap
-	mkdir -p brew-tap/Formula/
-	cp .packaging/homebrew/xcsp.rb brew-tap/Formula/xcsp.rb
-	cd brew-tap && git add Formula/ && git commit -m "Update formula for version $(VERSION)" && git push
-	rm -rf brew-tap
+# # Créer une Formula Homebrew à partir du tar.gz
+# brew: $(DIST_DIR)/$(BIN_NAME)
+# 	@echo "Building Homebrew formula..."
+#
+# 	# Générer un tar.gz contenant juste l'exécutable et les configs
+# 	mkdir -p brew_tmp/bin brew_tmp/share/xcsp-launcher/configs brew_tmp/share/xcsp-launcher/tools
+# 	cp $(DIST_DIR)/$(BIN_NAME) brew_tmp/bin/xcsp-macos
+# 	cp $(DIST_DIR)/${BIN_NAME} $(DIST_DIR)/xcsp-macos
+# 	cp -r configs/* brew_tmp/share/xcsp-launcher/configs/
+# 	cp xcsp/tools/xcsp3-solutionChecker-2.5.jar brew_tmp/share/xcsp-launcher/tools/xcsp3-solutionChecker-2.5.jar
+#
+# 	# Créer archive
+# 	tar -czvf xcsp-$(VERSION:v%=%)-macos.tar.gz -C brew_tmp .
+#
+# 	{ \
+# 		sha256=$$(shasum -a 256 xcsp-$(VERSION:v%=%)-macos.tar.gz | awk '{print $$1}'); \
+# 		url="https://github.com/CPToolset/xcsp-launcher/releases/download/$(VERSION)/xcsp-$(VERSION:v%=%)-macos.tar.gz"; \
+# 		sed \
+# 			-e "s|__URL__|$$url|" \
+# 			-e "s|__SHASUM__|$$sha256|" \
+# 			.packaging/homebrew/xcsp.rb.template > .packaging/homebrew/xcsp.rb; \
+# 	}
+#
+# 	# Nettoyer temporaire
+# 	rm -rf brew_tmp
+#
+# publish-brew: xcsp-*-macos.tar.gz
+# 	@echo "Publishing Homebrew Formula..."
+# 	git clone https://github.com/CPToolset/homebrew-xcsp-launcher.git brew-tap
+# 	mkdir -p brew-tap/Formula/
+# 	cp .packaging/homebrew/xcsp.rb brew-tap/Formula/xcsp.rb
+# 	cd brew-tap && git add Formula/ && git commit -m "Update formula for version $(VERSION)" && git push
+# 	rm -rf brew-tap
 
 pacman: $(DIST_DIR)/$(BIN_NAME)
 	mkdir -p package/usr/bin

--- a/tests/test_installed_solvers.py
+++ b/tests/test_installed_solvers.py
@@ -39,9 +39,9 @@ class TestSolver:
                 print(f"{solver} is not present in solutions.json file. We skip test.",file=sys.stderr)
                 return
             solution_for_current_instance = solutions[solver][instance.split("/")[-1]]
-            print(f"Test of ace with input {instance}", file=sys.stderr)
+            print(f"Test of {solver} with input {instance}", file=sys.stderr)
             for index, o in enumerate(solution_for_current_instance["solutions"]):
-                solver = Solver.lookup("ace")
+                solver = Solver.lookup(solver)
                 solver.set_limit_number_of_solutions(index + 1)
                 solver.solve(instance)
                 assert solver.objective_value() is not None
@@ -59,7 +59,7 @@ class TestSolver:
         (solver, instance) for solver in solvers for instance in instances_unsat
     ])
     def test_with_xcsp_file_unsat(self, solver, instance):
-        print(f"Test of ace with input {instance}", file=sys.stderr)
+        print(f"Test of {solver} with input {instance}", file=sys.stderr)
         solver = Solver.lookup(solver)
         solver.solve(instance)
         assert solver.objective_value() is None
@@ -69,7 +69,7 @@ class TestSolver:
         (solver, instance) for solver in solvers for instance in instances_unknown
     ])
     def test_with_xcsp_file_unknown(self, solver, instance):
-        print(f"Test of ace with input {instance}", file=sys.stderr)
+        print(f"Test of {solver} with input {instance}", file=sys.stderr)
         solver = Solver.lookup(solver)
         solver.set_time_limit(10)
         solver.solve(instance)

--- a/xcsp/commands/install.py
+++ b/xcsp/commands/install.py
@@ -351,9 +351,12 @@ class Installer:
                     elif executable_path.is_file():
                         result_path = shutil.copy(Path(self._repo.get_source_path()) / v["executable"],
                                                   bin_dir / executable_path.name)
+                        final_placeholder_for_executable = bin_dir/executable_path.name
                         logger.success(f"Executable for version '{v['version']}' successfully copied to {result_path}.")
 
                     if self._config is not None and self._config.get("command") is not None:
+                        result_cmd = build_cmd(self._config, final_placeholder_for_executable , bin_dir)
+                        logger.debug(result_cmd)
                         CACHE[self._id]["versions"][v['version']] = {
                             "options": self._config["command"].get("options", dict()),
                             "cmd": build_cmd(self._config, final_placeholder_for_executable , bin_dir),


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

This PR extends executable handling:

* In addition to single files, it is now possible to provide a **directory** as an executable.
* When a directory is specified, **its full content is copied** into the binary directory, instead of only handling a single file.

This allows more flexibility, for example when an executable requires multiple files (scripts, configs, assets) to run properly.

See the configuration of [Sat4J](https://github.com/crillab/metrics-solvers/blob/main/sat4j-csp-pb.solver.yaml) that used this feature. 